### PR TITLE
Bump to v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
   # Method 3: Combined filtering (most flexible)
   ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
   ```
+- The `--keywords` and `--keywords-exclude` features for keyword filtering and exclusion can now also be set in the configuration
+  - New configuration options:
+    - `job.keywords`: Keyword filtering (default is empty)
+    - `job.keywords_exclude`: Keyword exclusion (default is empty)
+  - You can edit these configurations by running `ktoolbox config-editor` (`Job -> ...`)
+  - Or manually edit them in the `.env` file or environment variables
+    ```dotenv
+    KTOOLBOX_JOB__KEYWORDS='["expression", "sound effect variation"]'
+    KTOOLBOX_JOB__KEYWORDS_EXCLUDE='["public", "result announcement"]'
+    ```
+  - 📖More information: [Configuration-Reference-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
 - Add **year/month** **grouping** functionality for post organization - #306
   - You can group downloaded posts by year and month with customizable directory naming formats
   - New configuration options:
@@ -26,12 +37,12 @@
   - Or manually edit them in `.env` file or environment variables
     ```dotenv
     # Environment variables (Defaults to False)
-    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
-    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
+    KTOOLBOX_JOB__GROUP_BY_YEAR=True
+    KTOOLBOX_JOB__GROUP_BY_MONTH=True
   
     # Custom style naming
-    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="Year {year}"
-    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="Month {month:02d}"
+    KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="Year {year}"
+    KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="Month {month:02d}"
     ```
     Resulting directory structure:
     ```
@@ -65,6 +76,17 @@
   # 方法3：组合筛选（最灵活）
   ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
   ```
+- 关键词筛选和关键词排除的 `--keywords` 和 `--keywords-exclude` 功能现在也可以在配置中设置
+  - 新配置项：
+    - `job.keywords`：关键词筛选（默认为空）
+    - `job.keywords_exclude`：关键词排除（默认为空）
+  - 可通过运行 `ktoolbox config-editor` 编辑这些配置（`Job -> ...`）
+  - 或手动在 `.env` 文件或环境变量中编辑
+    ```dotenv
+    KTOOLBOX_JOB__KEYWORDS='["表情", "効果音差分"]'
+    KTOOLBOX_JOB__KEYWORDS_EXCLUDE='["全体公開", "結果発表"]'
+    ```
+  - 📖更多信息：[配置参考-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
 - 新增按**年份/月**分组功能用于帖子整理 - #306
   - 可按年份和月份分组下载的帖子，支持自定义目录命名格式
   - 新配置项：
@@ -75,13 +97,13 @@
   - 可通过运行 `ktoolbox config-editor` 编辑这些配置（`Job -> ...`）
   - 或手动在 `.env` 文件或环境变量中编辑
     ```dotenv
-    # 环境变量（默认 False）
-    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
-    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
+    # 是否启用（默认 False）
+    KTOOLBOX_JOB__GROUP_BY_YEAR=True
+    KTOOLBOX_JOB__GROUP_BY_MONTH=True
   
     # 自定义目录命名
-    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="{year}年"
-    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="{month:02d}月"
+    KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="{year}年"
+    KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="{month:02d}月"
     ```
     目录结构示例：
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@
   - 📖More information: [Configuration-Reference-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
 
 
-[//]: # (### 🪲 Fix)
+### 🪲 Fix
+
+- Fixed the issue where the `--keywords` parameter could not be parsed correctly in the `sync-creator` command
 
 - - -
 
@@ -119,7 +121,9 @@
     ```
   - 📖更多信息：[配置参考-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
 
-[//]: # (### 🪲 修复)
+### 🪲 修复
+
+- 修复 `--keywords` 参数在 `sync-creator` 命令中无法正确解析的问题
 
 ## Upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,103 @@
 ## Changes
 
-![Downloads](https://img.shields.io/github/downloads/Ljzd-PRO/KToolBox/v0.18.2/total)
+![Downloads](https://img.shields.io/github/downloads/Ljzd-PRO/KToolBox/v0.19.0/total)
 
-[//]: # (### 💡 Feature)
+### 💡 Feature
 
-### 🪲 Fix
+- Add **`--keywords-exclude`** parameter for post filtering - #309
+  ```shell
+  # Method 1: Include only specific character posts
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="release"
 
-- Fixed the issue where **warning messages** were displayed regardless of whether **`job.include_revisions`** was enabled or not.
-- Fixed the issue where extracted external links contained extra characters (v0.18.0)
-  - Related configuration options: `job.extract_external_links`, `job.external_link_patterns`
+  # Method 2: Exclude unwanted character posts (OR logic)
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords_exclude="announcement,vote,share"
+  
+  # Method 3: Combined filtering (most flexible)
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
+  ```
+- Add **year/month** **grouping** functionality for post organization - #306
+  - You can group downloaded posts by year and month with customizable directory naming formats
+  - New configuration options:
+    - `job.group_by_year`: Enable grouping by year (Disabled by default)
+    - `job.group_by_month`: Enable grouping by month (Disabled by default)
+    - `job.year_month_format`: Customize the directory naming format for year grouping (Defaults to `{year}`)
+    - `job.month_format`: Customize the directory naming format for month grouping (Defaults to `{year}-{month:02d}`)
+  - Run `ktoolbox config-editor` to edit these configurations (`Job -> ...`)
+  - Or manually edit them in `.env` file or environment variables
+    ```dotenv
+    # Environment variables (Defaults to False)
+    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
+    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
+  
+    # Custom style naming
+    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="Year {year}"
+    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="Month {month:02d}"
+    ```
+    Resulting directory structure:
+    ```
+    creator/
+    ├── Year 2020/
+    │   ├── Month 01/
+    │   │   └── post_title/
+    │   └── Month 12/
+    │       └── another_post/
+    └── Year 2021/
+        └── Month 03/
+            └── latest_post/
+    ```
+  - 📖More information: [Configuration-Reference-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
+
+
+[//]: # (### 🪲 Fix)
 
 - - -
 
-[//]: # (### 💡 新特性)
+### 💡 新特性
 
-### 🪲 修复
+- 新增 **`--keywords-exclude`** 参数用于帖子筛选 - #309
+  ```shell
+  # 方法1：仅包含特定关键词的帖子
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="发布"
 
-- 修复了无论是否开启 **`job.include_revisions`** 都会提示**警告信息**的问题
-- 修复了程序提取的外部链接（external links）包含多余字符的问题 (v0.18.0)
-  - 相关配置选项：`job.extract_external_links`, `job.external_link_patterns`
+  # 方法2：排除不需要的关键词帖子（或逻辑）
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords_exclude="公告,投票,分享"
+  
+  # 方法3：组合筛选（最灵活）
+  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
+  ```
+- 新增按**年份/月**分组功能用于帖子整理 - #306
+  - 可按年份和月份分组下载的帖子，支持自定义目录命名格式
+  - 新配置项：
+    - `job.group_by_year`：启用按年份分组（默认关闭）
+    - `job.group_by_month`：启用按月份分组（默认关闭）
+    - `job.year_month_format`：自定义年份分组目录命名格式（默认为 `{year}`）
+    - `job.month_format`：自定义月份分组目录命名格式（默认为 `{year}-{month:02d}`）
+  - 可通过运行 `ktoolbox config-editor` 编辑这些配置（`Job -> ...`）
+  - 或手动在 `.env` 文件或环境变量中编辑
+    ```dotenv
+    # 环境变量（默认 False）
+    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
+    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
+  
+    # 自定义目录命名
+    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="{year}年"
+    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="{month:02d}月"
+    ```
+    目录结构示例：
+    ```
+    creator/
+    ├── 2020年/
+    │   ├── 01月/
+    │   │   └── post_title/
+    │   └── 12月/
+    │       └── another_post/
+    └── 2021年/
+        └── 03月/
+            └── latest_post/
+    ```
+  - 📖更多信息：[配置参考-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)
+
+[//]: # (### 🪲 修复)
 
 ## Upgrade
 
@@ -27,4 +106,4 @@ Use this command to upgrade if you are using **pipx**:
 pipx upgrade ktoolbox
 ```
 
-**Full Changelog**: https://github.com/Ljzd-PRO/KToolBox/compare/v0.18.1...v0.18.2
+**Full Changelog**: https://github.com/Ljzd-PRO/KToolBox/compare/v0.18.2...v0.19.0

--- a/ktoolbox/__init__.py
+++ b/ktoolbox/__init__.py
@@ -1,4 +1,4 @@
 __title__ = "KToolBox"
 # noinspection SpellCheckingInspection
 __description__ = "A useful CLI tool for downloading posts in Kemono.cr / .su / .party"
-__version__ = "v0.18.2"
+__version__ = "v0.19.0"

--- a/ktoolbox/_cli_zh.py
+++ b/ktoolbox/_cli_zh.py
@@ -173,7 +173,8 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
             mix_posts: bool = None,
             start_time: str = None,
             end_time: str = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         """
         同步创作者所有帖子（通过 URL）
@@ -185,6 +186,7 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
         :param start_time: 帖子发布时间范围起始
         :param end_time: 帖子发布时间范围结束
         :param keywords: 按标题过滤帖子，逗号分隔关键词
+        :param keywords_exclude: 按标题排除帖子，逗号分隔关键词
         """
         ...
 
@@ -199,7 +201,8 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
             mix_posts: bool = None,
             start_time: str = None,
             end_time: str = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         """
         同步创作者所有帖子（通过参数）
@@ -212,6 +215,7 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
         :param start_time: 帖子发布时间范围起始
         :param end_time: 帖子发布时间范围结束
         :param keywords: 按标题过滤帖子，逗号分隔关键词
+        :param keywords_exclude: 按标题排除帖子，逗号分隔关键词
         """
         ...
 
@@ -228,7 +232,8 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
             end_time: str = None,
             offset: int = 0,
             length: int = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         """
         同步创作者所有帖子
@@ -248,6 +253,7 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
         :param offset: 结果偏移量
         :param length: 获取帖子数量，默认为全部
         :param keywords: 按标题过滤帖子，逗号分隔关键词
+        :param keywords_exclude: 按标题排除帖子，逗号分隔关键词
         """
         return await super().sync_creator(
             url=url,
@@ -260,5 +266,6 @@ class KToolBoxCli(ktoolbox.cli.KToolBoxCli):
             end_time=end_time,
             offset=offset,
             length=length,
-            keywords=keywords
+            keywords=keywords,
+            keywords_exclude=keywords_exclude
         )

--- a/ktoolbox/_configuration_zh.py
+++ b/ktoolbox/_configuration_zh.py
@@ -101,6 +101,13 @@ class JobConfiguration(ktoolbox.configuration.JobConfiguration):
         | ``published``| 日期   |
         | ``edited``   | 日期   |
 
+    - ``year_dirname_format`` 和 ``month_dirname_format`` 可用属性
+
+        | 属性         | 类型   |
+        |--------------|--------|
+        | ``year``     | 字符串 |
+        | ``month``    | 字符串 |
+
     :ivar count: 并发下载的协程数量
     :ivar include_revisions: 下载时包含修订帖子
     :ivar post_dirname_format: 自定义帖子目录名格式，可使用 [属性][ktoolbox.configuration.JobConfiguration]。例如：``[{published}]{id}`` > ``[2024-1-1]123123``，``{user}_{published}_{title}`` > ``234234_2024-1-1_TheTitle``
@@ -113,6 +120,10 @@ class JobConfiguration(ktoolbox.configuration.JobConfiguration):
     :ivar block_list: 不下载匹配这些模式（Unix shell 风格）的文件，如 ``["*.psd","*.zip"]``
     :ivar extract_external_links: 从帖子内容中提取外部文件分享链接并保存到单独文件
     :ivar external_link_patterns: 用于提取外部链接的正则表达式模式
+    :ivar group_by_year: 根据发布日期按年分组到不同目录
+    :ivar group_by_month: 根据发布日期按月分组到不同目录（需要启用 group_by_year）
+    :ivar year_dirname_format: 自定义年份目录名格式。可用属性：``year``。例如：``{year}`` > ``2024``，``Year_{year}`` > ``Year_2024``
+    :ivar month_dirname_format: 自定义月份目录名格式。可用属性：``year``、``month``。例如：``{year}-{month}`` > ``2024-01``，``{year}_{month}`` > ``2024_01``
     """
     ...
 

--- a/ktoolbox/action/job.py
+++ b/ktoolbox/action/job.py
@@ -11,7 +11,7 @@ from pathvalidate import sanitize_filename, is_valid_filename
 
 from ktoolbox._enum import PostFileTypeEnum, DataStorageNameEnum
 from ktoolbox.action import ActionRet, fetch_creator_posts, FetchInterruptError
-from ktoolbox.action.utils import generate_post_path_name, filter_posts_by_date, generate_filename, filter_posts_by_keywords
+from ktoolbox.action.utils import generate_post_path_name, filter_posts_by_date, generate_filename, filter_posts_by_keywords, filter_posts_by_keywords_exclude
 from ktoolbox.api.model import Post, Attachment
 from ktoolbox.api.posts import get_post_revisions as get_post_revisions_api
 from ktoolbox.configuration import config, PostStructureConfiguration
@@ -155,7 +155,8 @@ async def create_job_from_creator(
         mix_posts: bool = None,
         start_time: Optional[datetime],
         end_time: Optional[datetime],
-        keywords: Optional[Set[str]] = None
+        keywords: Optional[Set[str]] = None,
+        keywords_exclude: Optional[Set[str]] = None
 ) -> ActionRet[List[Job]]:
     """
     Create a list of download job from a creator
@@ -172,6 +173,7 @@ async def create_job_from_creator(
     :param start_time: Start time of the time range
     :param end_time: End time of the time range
     :param keywords: Set of keywords to filter posts by title (case-insensitive)
+    :param keywords_exclude: Set of keywords to exclude posts by title (case-insensitive)
     """
     mix_posts = config.job.mix_posts if mix_posts is None else mix_posts
 
@@ -206,6 +208,10 @@ async def create_job_from_creator(
     # Filter posts by keywords
     if keywords:
         post_list = list(filter_posts_by_keywords(post_list, keywords))
+        
+    # Filter out posts by exclude keywords
+    if keywords_exclude:
+        post_list = list(filter_posts_by_keywords_exclude(post_list, keywords_exclude))
         
     logger.info(f"Get {len(post_list)} posts after filtering, start creating jobs")
 

--- a/ktoolbox/action/job.py
+++ b/ktoolbox/action/job.py
@@ -11,7 +11,7 @@ from pathvalidate import sanitize_filename, is_valid_filename
 
 from ktoolbox._enum import PostFileTypeEnum, DataStorageNameEnum
 from ktoolbox.action import ActionRet, fetch_creator_posts, FetchInterruptError
-from ktoolbox.action.utils import generate_post_path_name, filter_posts_by_date, generate_filename, filter_posts_by_keywords, filter_posts_by_keywords_exclude
+from ktoolbox.action.utils import generate_post_path_name, filter_posts_by_date, generate_filename, filter_posts_by_keywords, filter_posts_by_keywords_exclude, generate_grouped_post_path
 from ktoolbox.api.model import Post, Attachment
 from ktoolbox.api.posts import get_post_revisions as get_post_revisions_api
 from ktoolbox.configuration import config, PostStructureConfiguration
@@ -218,11 +218,17 @@ async def create_job_from_creator(
     # Filter posts and generate ``CreatorIndices``
     if not mix_posts:
         if save_creator_indices:
+            # Generate posts_path with year/month grouping if enabled
+            posts_path = {}
+            for post in post_list:
+                grouped_base_path = generate_grouped_post_path(post, path)
+                posts_path[post.id] = grouped_base_path / sanitize_filename(post.title)
+            
             indices = CreatorIndices(
                 creator_id=creator_id,
                 service=service,
                 posts={post.id: post for post in post_list},
-                posts_path={post.id: path / sanitize_filename(post.title) for post in post_list}
+                posts_path=posts_path
             )
             async with aiofiles.open(
                     path / DataStorageNameEnum.CreatorIndicesData.value,
@@ -238,7 +244,12 @@ async def create_job_from_creator(
     job_list: List[Job] = []
     for post in post_list:
         # Get post path
-        post_path = path if mix_posts else path / generate_post_path_name(post)
+        if mix_posts:
+            post_path = path
+        else:
+            # Apply year/month grouping if enabled
+            grouped_base_path = generate_grouped_post_path(post, path)
+            post_path = grouped_base_path / generate_post_path_name(post)
 
         # Generate jobs for the main post
         job_list += await create_job_from_post(

--- a/ktoolbox/action/utils.py
+++ b/ktoolbox/action/utils.py
@@ -15,7 +15,8 @@ __all__ = [
     "filter_posts_by_date",
     "filter_posts_by_indices",
     "match_post_keywords",
-    "filter_posts_by_keywords"
+    "filter_posts_by_keywords",
+    "filter_posts_by_keywords_exclude"
 ]
 
 TIME_FORMAT = "%Y-%m-%d"
@@ -159,4 +160,23 @@ def filter_posts_by_keywords(
         return
     
     post_filter = filter(lambda x: match_post_keywords(x, keywords), post_list)
+    yield from post_filter
+
+
+def filter_posts_by_keywords_exclude(
+        post_list: List[Post],
+        keywords_exclude: Optional[Set[str]]
+) -> Generator[Post, Any, Any]:
+    """
+    Filter out posts that contain any of the specified keywords in title
+
+    :param post_list: List of posts
+    :param keywords_exclude: Set of keywords to exclude (case-insensitive), None means no filtering
+    """
+    if not keywords_exclude:
+        yield from post_list
+        return
+    
+    # Exclude posts that match any of the exclude keywords
+    post_filter = filter(lambda x: not match_post_keywords(x, keywords_exclude), post_list)
     yield from post_filter

--- a/ktoolbox/action/utils.py
+++ b/ktoolbox/action/utils.py
@@ -12,6 +12,9 @@ from ktoolbox.job import CreatorIndices
 __all__ = [
     "generate_post_path_name",
     "generate_filename",
+    "generate_year_dirname",
+    "generate_month_dirname",
+    "generate_grouped_post_path",
     "filter_posts_by_date",
     "filter_posts_by_indices",
     "match_post_keywords",
@@ -42,6 +45,64 @@ def generate_post_path_name(post: Post) -> str:
         except KeyError as e:
             logger.error(f"`JobConfiguration.post_dirname_format` contains invalid key: {e}")
             exit(1)
+
+
+def generate_year_dirname(post: Post) -> str:
+    """Generate year directory name for post grouping."""
+    # Use published date, fall back to added date
+    post_date = post.published or post.added
+    if not post_date:
+        return "unknown"
+    
+    try:
+        return sanitize_filename(
+            config.job.year_dirname_format.format(
+                year=post_date.year
+            )
+        )
+    except KeyError as e:
+        logger.error(f"`JobConfiguration.year_dirname_format` contains invalid key: {e}")
+        exit(1)
+
+
+def generate_month_dirname(post: Post) -> str:
+    """Generate month directory name for post grouping."""
+    # Use published date, fall back to added date
+    post_date = post.published or post.added
+    if not post_date:
+        return "unknown"
+    
+    try:
+        return sanitize_filename(
+            config.job.month_dirname_format.format(
+                year=post_date.year,
+                month=post_date.month
+            )
+        )
+    except KeyError as e:
+        logger.error(f"`JobConfiguration.month_dirname_format` contains invalid key: {e}")
+        exit(1)
+
+
+def generate_grouped_post_path(post: Post, base_path: Path) -> Path:
+    """
+    Generate the full path for a post considering year/month grouping.
+    
+    :param post: Post object
+    :param base_path: Base path (usually creator directory)
+    :return: Full path where the post should be saved
+    """
+    result_path = base_path
+    
+    if config.job.group_by_year:
+        year_dirname = generate_year_dirname(post)
+        result_path = result_path / year_dirname
+        
+        if config.job.group_by_month:
+            month_dirname = generate_month_dirname(post)
+            result_path = result_path / month_dirname
+    
+    return result_path
 
 
 def generate_filename(post: Post, basic_name: str, filename_format: str) -> str:

--- a/ktoolbox/cli.py
+++ b/ktoolbox/cli.py
@@ -353,16 +353,13 @@ class KToolBoxCli:
             return creator_ret.message
 
         creator_path = path / sanitize_filename(creator_name)
-
         creator_path.mkdir(exist_ok=True)
 
-        # Parse keywords
-        keyword_set = set(keywords) if keywords else set()
+        keyword_set = set(keywords) if keywords else config.job.keywords
         if keywords:
             logger.info(f"Filtering posts by keywords: {', '.join(keyword_set)}")
 
-        # Parse exclude keywords
-        keyword_exclude_set = set(keywords_exclude) if keywords_exclude else set()
+        keyword_exclude_set = set(keywords_exclude) if keywords_exclude else config.job.keywords_exclude
         if keywords_exclude:
             logger.info(f"Excluding posts by keywords: {', '.join(keyword_exclude_set)}")
 

--- a/ktoolbox/cli.py
+++ b/ktoolbox/cli.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Union, overload, Set, Optional
+from typing import Union, overload, Tuple
 
 import aiofiles
 from loguru import logger
@@ -208,34 +208,35 @@ class KToolBoxCli:
         )
         if ret:
             post_path = path / generate_post_path_name(ret.data.post)
-            
+
             # For revision posts, create a revision subfolder
             if revision_id:
                 post_path = post_path / "revision" / revision_id
-                
+
             # Download the main post
             job_list = await create_job_from_post(
                 post=ret.data.post,
                 post_path=post_path,
                 dump_post_data=dump_post_data
             )
-            
+
             # If include_revisions is enabled and we have revisions data
             if (config.job.include_revisions and
-                ret.data.props and 
-                ret.data.props.revisions and 
-                not revision_id):  # Don't process revisions if we're already downloading a specific revision
-                
+                    ret.data.props and
+                    ret.data.props.revisions and
+                    not revision_id):  # Don't process revisions if we're already downloading a specific revision
+
                 for revision_order, revision_data in ret.data.props.revisions:
                     if revision_data.revision_id:  # Only process actual revisions, not the main post
-                        revision_path = post_path / config.job.post_structure.revisions / generate_post_path_name(revision_data)
+                        revision_path = post_path / config.job.post_structure.revisions / generate_post_path_name(
+                            revision_data)
                         revision_jobs = await create_job_from_post(
                             post=revision_data,
                             post_path=revision_path,
                             dump_post_data=dump_post_data
                         )
                         job_list.extend(revision_jobs)
-            
+
             job_runner = JobRunner(job_list=job_list)
             await job_runner.start()
         else:
@@ -285,8 +286,8 @@ class KToolBoxCli:
             end_time: str = None,
             offset: int = 0,
             length: int = None,
-            keywords: str = None,
-            keywords_exclude: str = None
+            keywords: Tuple[str] = None,
+            keywords_exclude: Tuple[str] = None
     ):
         """
         Sync posts from a creator
@@ -354,21 +355,17 @@ class KToolBoxCli:
         creator_path = path / sanitize_filename(creator_name)
 
         creator_path.mkdir(exist_ok=True)
-        
+
         # Parse keywords
-        keyword_set: Optional[Set[str]] = None
+        keyword_set = set(keywords) if keywords else set()
         if keywords:
-            keyword_set = set(kw.strip() for kw in keywords.split(',') if kw.strip())
-            if keyword_set:
-                logger.info(f"Filtering posts by keywords: {', '.join(keyword_set)}")
-        
+            logger.info(f"Filtering posts by keywords: {', '.join(keyword_set)}")
+
         # Parse exclude keywords
-        keyword_exclude_set: Optional[Set[str]] = None
+        keyword_exclude_set = set(keywords_exclude) if keywords_exclude else set()
         if keywords_exclude:
-            keyword_exclude_set = set(kw.strip() for kw in keywords_exclude.split(',') if kw.strip())
-            if keyword_exclude_set:
-                logger.info(f"Excluding posts by keywords: {', '.join(keyword_exclude_set)}")
-        
+            logger.info(f"Excluding posts by keywords: {', '.join(keyword_exclude_set)}")
+
         ret = await create_job_from_creator(
             service=service,
             creator_id=creator_id,

--- a/ktoolbox/cli.py
+++ b/ktoolbox/cli.py
@@ -355,10 +355,12 @@ class KToolBoxCli:
         creator_path = path / sanitize_filename(creator_name)
         creator_path.mkdir(exist_ok=True)
 
+        keywords = [keywords] if isinstance(keywords, str) else keywords
         keyword_set = set(keywords) if keywords else config.job.keywords
         if keywords:
             logger.info(f"Filtering posts by keywords: {', '.join(keyword_set)}")
 
+        keywords_exclude = [keywords_exclude] if isinstance(keywords_exclude, str) else keywords_exclude
         keyword_exclude_set = set(keywords_exclude) if keywords_exclude else config.job.keywords_exclude
         if keywords_exclude:
             logger.info(f"Excluding posts by keywords: {', '.join(keyword_exclude_set)}")

--- a/ktoolbox/cli.py
+++ b/ktoolbox/cli.py
@@ -251,7 +251,8 @@ class KToolBoxCli:
             mix_posts: bool = None,
             start_time: str = None,
             end_time: str = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         ...
 
@@ -266,7 +267,8 @@ class KToolBoxCli:
             mix_posts: bool = None,
             start_time: str = None,
             end_time: str = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         ...
 
@@ -283,7 +285,8 @@ class KToolBoxCli:
             end_time: str = None,
             offset: int = 0,
             length: int = None,
-            keywords: str = None
+            keywords: str = None,
+            keywords_exclude: str = None
     ):
         """
         Sync posts from a creator
@@ -309,6 +312,7 @@ class KToolBoxCli:
         :param offset: Result offset (or start offset)
         :param length: The number of posts to fetch, defaults to fetching all posts after ``offset``.
         :param keywords: Comma-separated keywords to filter posts by title (case-insensitive)
+        :param keywords_exclude: Comma-separated keywords to exclude posts by title (case-insensitive)
         """
         logger.info(repr(config))
         # Get service, creator_id
@@ -358,6 +362,13 @@ class KToolBoxCli:
             if keyword_set:
                 logger.info(f"Filtering posts by keywords: {', '.join(keyword_set)}")
         
+        # Parse exclude keywords
+        keyword_exclude_set: Optional[Set[str]] = None
+        if keywords_exclude:
+            keyword_exclude_set = set(kw.strip() for kw in keywords_exclude.split(',') if kw.strip())
+            if keyword_exclude_set:
+                logger.info(f"Excluding posts by keywords: {', '.join(keyword_exclude_set)}")
+        
         ret = await create_job_from_creator(
             service=service,
             creator_id=creator_id,
@@ -369,7 +380,8 @@ class KToolBoxCli:
             mix_posts=mix_posts,
             start_time=datetime.strptime(start_time, "%Y-%m-%d") if start_time else None,
             end_time=datetime.strptime(end_time, "%Y-%m-%d") if end_time else None,
-            keywords=keyword_set
+            keywords=keyword_set,
+            keywords_exclude=keyword_exclude_set
         )
         if ret:
             job_runner = JobRunner(job_list=ret.data)

--- a/ktoolbox/configuration.py
+++ b/ktoolbox/configuration.py
@@ -169,6 +169,13 @@ class JobConfiguration(BaseModel):
         | ``published`` | Date   |
         | ``edited``    | Date   |
 
+    - Available properties for ``year_dirname_format`` and ``month_dirname_format``
+
+        | Property      | Type   |
+        |---------------|--------|
+        | ``year``      | String |
+        | ``month``     | String |
+
     :ivar count: Number of coroutines for concurrent download
     :ivar include_revisions: Include and download revision posts when available
     :ivar post_dirname_format: Customize the post directory name format, you can use some of the \
@@ -190,6 +197,12 @@ class JobConfiguration(BaseModel):
     :ivar block_list: Not to download files which match these patterns (Unix shell-style), e.g. ``["*.psd","*.zip"]``
     :ivar extract_external_links: Extract external file sharing links from post content and save to separate file
     :ivar external_link_patterns: Regex patterns for extracting external links.
+    :ivar group_by_year: Group posts by year in separate directories based on published date
+    :ivar group_by_month: Group posts by month in separate directories based on published date (requires group_by_year)
+    :ivar year_dirname_format: Customize the year directory name format. Available properties: ``year``. \
+    e.g. ``{year}`` > ``2024``, ``Year_{year}`` > ``Year_2024``
+    :ivar month_dirname_format: Customize the month directory name format. Available properties: ``year``, ``month``. \
+    e.g. ``{year}-{month}`` > ``2024-01``, ``{year}_{month}`` > ``2024_01``
     """
     count: int = 4
     include_revisions: bool = False
@@ -252,6 +265,10 @@ class JobConfiguration(BaseModel):
         # Generic patterns for other file hosting services
         r'https?://[^\s]*(?:file|upload|share|download|drive|storage)[^\s]*\.[a-z]{2,4}/[^\s]+',
     ]
+    group_by_year: bool = False
+    group_by_month: bool = False
+    year_dirname_format: str = "{year}"
+    month_dirname_format: str = "{year}-{month:02d}"
 
 
 class LoggerConfiguration(BaseModel):

--- a/ktoolbox/configuration.py
+++ b/ktoolbox/configuration.py
@@ -203,6 +203,8 @@ class JobConfiguration(BaseModel):
     e.g. ``{year}`` > ``2024``, ``Year_{year}`` > ``Year_2024``
     :ivar month_dirname_format: Customize the month directory name format. Available properties: ``year``, ``month``. \
     e.g. ``{year}-{month}`` > ``2024-01``, ``{year}_{month}`` > ``2024_01``
+    :ivar keywords: keywords to filter posts by title (case-insensitive)
+    :ivar keywords_exclude: keywords to exclude posts by title (case-insensitive)
     """
     count: int = 4
     include_revisions: bool = False
@@ -269,6 +271,8 @@ class JobConfiguration(BaseModel):
     group_by_month: bool = False
     year_dirname_format: str = "{year}"
     month_dirname_format: str = "{year}-{month:02d}"
+    keywords: Set[str] = Field(default_factory=set)
+    keywords_exclude: Set[str] = Field(default_factory=set)
 
 
 class LoggerConfiguration(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ktoolbox"
-version = "v0.18.2"
+version = "v0.19.0"
 description = "A useful CLI tool for downloading posts in Kemono.cr / .su / .party"
 authors = ["Ljzd-PRO <me@ljzd.link>"]
 readme = "README.md"

--- a/tests/ktoolbox/test_year_month_grouping.py
+++ b/tests/ktoolbox/test_year_month_grouping.py
@@ -1,0 +1,186 @@
+import pytest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from ktoolbox.action.utils import generate_year_dirname, generate_month_dirname, generate_grouped_post_path
+from ktoolbox.api.model import Post
+from ktoolbox.configuration import config
+
+
+@pytest.fixture
+def sample_post():
+    """Create a sample post for testing"""
+    return Post(
+        id="test123",
+        user="testuser",
+        service="fanbox", 
+        title="Test Post",
+        content="Test content",
+        published=datetime(2024, 3, 15),
+        added=datetime(2024, 3, 10),
+        edited=datetime(2024, 3, 20),
+        attachments=[],
+        file=None
+    )
+
+
+@pytest.fixture
+def sample_post_no_published():
+    """Create a sample post without published date"""
+    return Post(
+        id="test456",
+        user="testuser",
+        service="fanbox",
+        title="Test Post No Published",
+        content="Test content",
+        published=None,
+        added=datetime(2023, 12, 25),
+        edited=datetime(2023, 12, 26),
+        attachments=[],
+        file=None
+    )
+
+
+@pytest.fixture
+def sample_post_no_dates():
+    """Create a sample post without any dates"""
+    return Post(
+        id="test789",
+        user="testuser", 
+        service="fanbox",
+        title="Test Post No Dates",
+        content="Test content",
+        published=None,
+        added=None,
+        edited=None,
+        attachments=[],
+        file=None
+    )
+
+
+def test_generate_year_dirname_default_format(sample_post):
+    """Test year directory generation with default format"""
+    result = generate_year_dirname(sample_post)
+    assert result == "2024"
+
+
+def test_generate_year_dirname_custom_format(sample_post):
+    """Test year directory generation with custom format"""
+    with patch.object(config.job, 'year_dirname_format', 'Year_{year}'):
+        result = generate_year_dirname(sample_post)
+        assert result == "Year_2024"
+
+
+def test_generate_year_dirname_fallback_to_added(sample_post_no_published):
+    """Test year directory generation falls back to added date"""
+    result = generate_year_dirname(sample_post_no_published)
+    assert result == "2023"
+
+
+def test_generate_year_dirname_no_dates(sample_post_no_dates):
+    """Test year directory generation with no dates"""
+    result = generate_year_dirname(sample_post_no_dates)
+    assert result == "unknown"
+
+
+def test_generate_month_dirname_default_format(sample_post):
+    """Test month directory generation with default format"""
+    result = generate_month_dirname(sample_post)
+    assert result == "2024-03"
+
+
+def test_generate_month_dirname_custom_format(sample_post):
+    """Test month directory generation with custom format"""
+    with patch.object(config.job, 'month_dirname_format', '{year}_{month:02d}'):
+        result = generate_month_dirname(sample_post)
+        assert result == "2024_03"
+
+
+def test_generate_month_dirname_fallback_to_added(sample_post_no_published):
+    """Test month directory generation falls back to added date"""
+    result = generate_month_dirname(sample_post_no_published)
+    assert result == "2023-12"
+
+
+def test_generate_month_dirname_no_dates(sample_post_no_dates):
+    """Test month directory generation with no dates"""
+    result = generate_month_dirname(sample_post_no_dates)
+    assert result == "unknown"
+
+
+def test_generate_grouped_post_path_no_grouping(sample_post):
+    """Test path generation with no grouping enabled"""
+    base_path = Path("/test/creator")
+    with patch.object(config.job, 'group_by_year', False):
+        with patch.object(config.job, 'group_by_month', False):
+            result = generate_grouped_post_path(sample_post, base_path)
+            assert result == base_path
+
+
+def test_generate_grouped_post_path_year_only(sample_post):
+    """Test path generation with year grouping only"""
+    base_path = Path("/test/creator")
+    with patch.object(config.job, 'group_by_year', True):
+        with patch.object(config.job, 'group_by_month', False):
+            result = generate_grouped_post_path(sample_post, base_path)
+            assert result == base_path / "2024"
+
+
+def test_generate_grouped_post_path_year_and_month(sample_post):
+    """Test path generation with both year and month grouping"""
+    base_path = Path("/test/creator")
+    with patch.object(config.job, 'group_by_year', True):
+        with patch.object(config.job, 'group_by_month', True):
+            result = generate_grouped_post_path(sample_post, base_path)
+            assert result == base_path / "2024" / "2024-03"
+
+
+def test_generate_grouped_post_path_month_without_year(sample_post):
+    """Test path generation with month grouping but no year grouping"""
+    base_path = Path("/test/creator")
+    with patch.object(config.job, 'group_by_year', False):
+        with patch.object(config.job, 'group_by_month', True):
+            result = generate_grouped_post_path(sample_post, base_path)
+            # Month grouping should not work without year grouping
+            assert result == base_path
+
+
+def test_invalid_year_format_key():
+    """Test error handling for invalid year format key"""
+    sample_post = Post(
+        id="test123",
+        user="testuser",
+        service="fanbox",
+        title="Test Post",
+        content="Test content",
+        published=datetime(2024, 3, 15),
+        added=datetime(2024, 3, 10),
+        edited=datetime(2024, 3, 20),
+        attachments=[],
+        file=None
+    )
+    
+    with patch.object(config.job, 'year_dirname_format', '{invalid_key}'):
+        with pytest.raises(SystemExit):
+            generate_year_dirname(sample_post)
+
+
+def test_invalid_month_format_key():
+    """Test error handling for invalid month format key"""
+    sample_post = Post(
+        id="test123",
+        user="testuser",
+        service="fanbox",
+        title="Test Post",
+        content="Test content",
+        published=datetime(2024, 3, 15),
+        added=datetime(2024, 3, 10),
+        edited=datetime(2024, 3, 20),
+        attachments=[],
+        file=None
+    )
+    
+    with patch.object(config.job, 'month_dirname_format', '{invalid_key}'):
+        with pytest.raises(SystemExit):
+            generate_month_dirname(sample_post)


### PR DESCRIPTION
## Changes

### 💡 Feature

- Add **`--keywords-exclude`** parameter for post filtering - #309
  ```shell
  # Method 1: Include only specific character posts
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="release"

  # Method 2: Exclude unwanted character posts (OR logic)
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords_exclude="announcement,vote,share"
  
  # Method 3: Combined filtering (most flexible)
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
  ```
- Add **year/month** **grouping** functionality for post organization - #306
  - You can group downloaded posts by year and month with customizable directory naming formats
  - New configuration options:
    - `job.group_by_year`: Enable grouping by year (Disabled by default)
    - `job.group_by_month`: Enable grouping by month (Disabled by default)
    - `job.year_month_format`: Customize the directory naming format for year grouping (Defaults to `{year}`)
    - `job.month_format`: Customize the directory naming format for month grouping (Defaults to `{year}-{month:02d}`)
  - Run `ktoolbox config-editor` to edit these configurations (`Job -> ...`)
  - Or manually edit them in `.env` file or environment variables
    ```dotenv
    # Environment variables (Defaults to False)
    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
  
    # Custom style naming
    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="Year {year}"
    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="Month {month:02d}"
    ```
    Resulting directory structure:
    ```
    creator/
    ├── Year 2020/
    │   ├── Month 01/
    │   │   └── post_title/
    │   └── Month 12/
    │       └── another_post/
    └── Year 2021/
        └── Month 03/
            └── latest_post/
    ```
  - 📖More information: [Configuration-Reference-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)


[//]: # (### 🪲 Fix)

- - -

### 💡 新特性

- 新增 **`--keywords-exclude`** 参数用于帖子筛选 - #309
  ```shell
  # 方法1：仅包含特定关键词的帖子
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="发布"

  # 方法2：排除不需要的关键词帖子（或逻辑）
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords_exclude="公告,投票,分享"
  
  # 方法3：组合筛选（最灵活）
  ktoolbox sync_creator --url="https://kemono.cr/fanbox/user/32165989" --keywords="ブルアカ" --keywords_exclude="全体公開,結果発表"
  ```
- 新增按**年份/月**分组功能用于帖子整理 - #306
  - 可按年份和月份分组下载的帖子，支持自定义目录命名格式
  - 新配置项：
    - `job.group_by_year`：启用按年份分组（默认关闭）
    - `job.group_by_month`：启用按月份分组（默认关闭）
    - `job.year_month_format`：自定义年份分组目录命名格式（默认为 `{year}`）
    - `job.month_format`：自定义月份分组目录命名格式（默认为 `{year}-{month:02d}`）
  - 可通过运行 `ktoolbox config-editor` 编辑这些配置（`Job -> ...`）
  - 或手动在 `.env` 文件或环境变量中编辑
    ```dotenv
    # 环境变量（默认 False）
    export KTOOLBOX_JOB__GROUP_BY_YEAR=True
    export KTOOLBOX_JOB__GROUP_BY_MONTH=True
  
    # 自定义目录命名
    export KTOOLBOX_JOB__YEAR_DIRNAME_FORMAT="{year}年"
    export KTOOLBOX_JOB__MONTH_DIRNAME_FORMAT="{month:02d}月"
    ```
    目录结构示例：
    ```
    creator/
    ├── 2020年/
    │   ├── 01月/
    │   │   └── post_title/
    │   └── 12月/
    │       └── another_post/
    └── 2021年/
        └── 03月/
            └── latest_post/
    ```
  - 📖更多信息：[配置参考-JobConfiguration](https://ktoolbox.readthedocs.io/latest/configuration/reference/#ktoolbox.configuration.JobConfiguration)

[//]: # (### 🪲 修复)