### PR TITLE
Fix quotes in ktoolbox installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Manually install:
   pip3 install pipx
   
   # Windows
-  pipx install ktoolbox[urwid,winloop]
+  pipx install "ktoolbox[urwid,winloop]"
   # Linux / macOS
-  pipx install ktoolbox[urwid,uvloop]
+  pipx install "ktoolbox[urwid,uvloop]"
   ```
 
 - For [a-Shell](https://github.com/holzschu/a-shell) or [pyodide](https://pyodide.org/en/stable/), 


### PR DESCRIPTION
Updated installation commands for ktoolbox to use proper quotes.

### Pull Request Description

Windows / Linux `pipx` require quotes to wrap package name and groups when installing into groups.