### PR TITLE
Update installation instructions for pipx

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -80,11 +80,11 @@ You can use executables from [releases](https://github.com/Ljzd-PRO/KToolBox/rel
 === "Normal"
     Recommend to use pipx
     ```bash
-    pip3 install pipx
+    sudo apt update && sudo apt install pipx
     # Windows
-    pipx install ktoolbox[urwid,winloop]
+    pipx install "ktoolbox[urwid,winloop]"
     # Linux / macOS
-    pipx install ktoolbox[urwid,uvloop]
+    pipx install "ktoolbox[urwid,uvloop]"
     ```
 
 === "Pure Python"


### PR DESCRIPTION
- changed the way to install pipx by using apt  
- added quotes around "ktoolbox[urwid,uvloop]" & "ktoolbox[urwid,winloop]" because it doesn't register what you're trying to do otherwise.

### Pull Request Description

Please provide a brief description of the pull request, including its purpose and the issue it addresses, if applicable.

### Associated Issue

If this pull request is related to a specific issue, please provide a link or describe the issue here.
